### PR TITLE
[Issue #107][Enhancement] Change people-count icon

### DIFF
--- a/templates/room.html
+++ b/templates/room.html
@@ -110,7 +110,7 @@
 
       <!-- Navbar: People count -->
       <h3 class="navbar-text float-xs-right" style="color:white">
-        <i class="fa fa-user-plus" aria-hidden="true"></i>
+        <i class="fa fa-user" aria-hidden="true"></i>
         <div id="user_count" style="float:right; margin-left:10px;"></div>
       </h3>
     </nav>


### PR DESCRIPTION
The plus sign in the _fa-user-plus_ icon gives the impression that it is an __invite__ icon.
Removing it makes it look more like a _people count_ indicator.
**May be a personal opinion

Original Icon 
<img width="99" alt="screen shot 2017-11-05 at 2 04 06 am" src="https://user-images.githubusercontent.com/23400562/32407517-b58be916-c1cd-11e7-91b9-0f334d570c1f.png">
New Icon
<img width="602" alt="screen shot 2017-11-05 at 2 03 48 am" src="https://user-images.githubusercontent.com/23400562/32407518-b5b26dc0-c1cd-11e7-8803-98241336166d.png">

